### PR TITLE
28 deploy to GitHub pages

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,9 +1,10 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
   pull_request:
+    types: [opened, synchronize]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,6 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
+  push:
+    branches: [28-deploy-to-github-pages]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -2,7 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [28-deploy-to-github-pages]
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -32,6 +33,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-node@v4
 
       - name: Install dependencies
-        run: npm run install
+        run: npm install
 
       - name: Build project
         run: npm run build

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        run: npm run install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload built files
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+*~


### PR DESCRIPTION
Add GitHub Actions workflow to build and deploy to GitHub pages.

@tienhoah this is set up to build when there's a pull request and then deploy when it's merged to main. I'm guessing that's probably good for this project: main gets automatically deployed to a staging environment and deployment to production happens manually. Let me know if you want to do it differently.

@alexgleith I don't have the permissions needed to actually set up the deployment environment (`Branch "28-deploy-to-github-pages" is not allowed to deploy to github-pages due to environment protection rules.`) but I assume you can set that up and connect the custom subdomain?