### PR TITLE
Deploy Dashboard

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Build project
         run: npm run build
+        env:
+          COASTLINE_APP_MAP_TILER_API_KEY: ${{ secrets.MapTilerApiKey }}
 
       - name: Upload built files
         id: deployment

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build project
         run: npm run build
         env:
-          COASTLINE_APP_MAP_TILER_API_KEY: ${{ secrets.MapTilerApiKey }}
+          COASTLINE_APP_MAP_TILER_API_KEY: ${{ secrets.MAP_TILER_API_KEY }}
 
       - name: Upload built files
         id: deployment

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -21,10 +21,13 @@ jobs:
 
       - name: Upload built files
         id: deployment
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: dist/
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -2,8 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    tags:
-      - 'current-release'
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,10 +1,6 @@
 name: Deploy to GitHub Pages
 
 on:
-  release:
-    types: [published]
-  pull_request:
-    types: [opened, synchronize]
   workflow_dispatch:
 
 jobs:
@@ -34,7 +30,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,7 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - 'current-release'
 
 jobs:
   build:


### PR DESCRIPTION
- This will allow us to build and deploy by tagging the commit we want to deploy with `current-release`.
- Deployment will be to `https://digitalearthpacific.github.io/dep-coastline-change-dashboard/`.
- This needs to be merged to the default branch (`main`) before it will work,
- Requires the secret `MapTilerApiKey` to be set.